### PR TITLE
GitHub CI: Update the OS matrix and Action versions

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14 ]
         node-version: [20]
     name: "Build: ${{ matrix.os }} node ${{ matrix.node-version }}"
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,7 @@ jobs:
       # Save logs on failure so we can diagnose
       - name: Archive logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Build ${{ matrix.os }} node ${{ matrix.node-version }}
           path: /home/runner/.npm/_logs/


### PR DESCRIPTION
Add ubuntu-24.04, remove macos-11, and add macos-14. Update the upload-artifact Action to v4 (the latest) as v3 is scheduled for deprecation.